### PR TITLE
Fix mc player edit resource error

### DIFF
--- a/entities/Models/Eloquent/Account.php
+++ b/entities/Models/Eloquent/Account.php
@@ -3,6 +3,7 @@
 namespace Entities\Models\Eloquent;
 
 use Carbon\Carbon;
+use Entities\Resources\AccountResource;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -181,5 +182,10 @@ final class Account extends Authenticatable
         $this->totp_backup_code = null;
         $this->totp_last_used = null;
         $this->is_totp_enabled = false;
+    }
+
+    public function toResource()
+    {
+        return new AccountResource($this);
     }
 }

--- a/tests/Feature/PanelMinecraftPlayerEditTest.php
+++ b/tests/Feature/PanelMinecraftPlayerEditTest.php
@@ -18,6 +18,17 @@ class PanelMinecraftPlayerEditTest extends TestCase
             ->assertSee('Edit');
     }
 
+    /**
+     * @ticket 596
+     */
+    public function test_can_view_edit_form_with_active_account()
+    {
+        $mcPlayer = MinecraftPlayer::factory()->for(Account::factory())->create();
+        $this->actingAs($this->adminAccount())
+            ->get(route('front.panel.minecraft-players.edit', $mcPlayer))
+            ->assertOk();
+    }
+
     public function testCanChangeAssignedUser()
     {
         $mcPlayer = MinecraftPlayer::factory()->for(Account::factory()->create())->create();


### PR DESCRIPTION
## Overview of Changes
* Fixes error caused by using `->toResource()` function (fixes #569)

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
