### PR TITLE
fix: players having a non-null `last_seen_at` on first-time join

### DIFF
--- a/app/Core/Domains/Auditing/Components/WrappedArrayList.php
+++ b/app/Core/Domains/Auditing/Components/WrappedArrayList.php
@@ -4,6 +4,7 @@ namespace App\Core\Domains\Auditing\Components;
 
 use App\Core\Domains\Auditing\Changes\ArrayDiff\ArrayWrapState;
 use App\Core\Domains\Auditing\Changes\ArrayDiff\WrappedArrayEntry;
+use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
 class WrappedArrayList extends Component
@@ -29,7 +30,7 @@ class WrappedArrayList extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\Contracts\View\View|\Closure|string
+     * @return View|\Closure|string
      */
     public function render()
     {

--- a/app/Domains/BuilderRankApplications/Notifications/BuilderRankAppApprovedNotification.php
+++ b/app/Domains/BuilderRankApplications/Notifications/BuilderRankAppApprovedNotification.php
@@ -48,7 +48,7 @@ class BuilderRankAppApprovedNotification extends Notification implements ShouldQ
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/BuilderRankApplications/Notifications/BuilderRankAppDeclinedNotification.php
+++ b/app/Domains/BuilderRankApplications/Notifications/BuilderRankAppDeclinedNotification.php
@@ -46,7 +46,7 @@ class BuilderRankAppDeclinedNotification extends Notification implements ShouldQ
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/BuilderRankApplications/Notifications/BuilderRankAppSubmittedNotification.php
+++ b/app/Domains/BuilderRankApplications/Notifications/BuilderRankAppSubmittedNotification.php
@@ -56,7 +56,7 @@ class BuilderRankAppSubmittedNotification extends Notification implements Should
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/Donations/Notifications/DonationEndedNotification.php
+++ b/app/Domains/Donations/Notifications/DonationEndedNotification.php
@@ -43,7 +43,7 @@ class DonationEndedNotification extends Notification implements ShouldQueue
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/Donations/Notifications/DonationPerkStartedNotification.php
+++ b/app/Domains/Donations/Notifications/DonationPerkStartedNotification.php
@@ -51,7 +51,7 @@ class DonationPerkStartedNotification extends Notification implements ShouldQueu
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/Mfa/Notifications/MfaBackupCodeRegeneratedNotification.php
+++ b/app/Domains/Mfa/Notifications/MfaBackupCodeRegeneratedNotification.php
@@ -43,7 +43,7 @@ class MfaBackupCodeRegeneratedNotification extends Notification implements Shoul
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/Mfa/Notifications/MfaBackupCodeUsedNotification.php
+++ b/app/Domains/Mfa/Notifications/MfaBackupCodeUsedNotification.php
@@ -43,7 +43,7 @@ class MfaBackupCodeUsedNotification extends Notification implements ShouldQueue
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/Mfa/Notifications/MfaDisabledNotification.php
+++ b/app/Domains/Mfa/Notifications/MfaDisabledNotification.php
@@ -43,7 +43,7 @@ class MfaDisabledNotification extends Notification implements ShouldQueue
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/Mfa/Notifications/MfaEnabledNotification.php
+++ b/app/Domains/Mfa/Notifications/MfaEnabledNotification.php
@@ -43,7 +43,7 @@ class MfaEnabledNotification extends Notification implements ShouldQueue
      * Get the mail representation of the notification.
      *
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Domains/MinecraftRegistration/UseCases/VerifyMinecraftRegistration.php
+++ b/app/Domains/MinecraftRegistration/UseCases/VerifyMinecraftRegistration.php
@@ -56,7 +56,6 @@ class VerifyMinecraftRegistration
                 'account_id' => $account->id,
                 'uuid' => $registration->minecraft_uuid,
                 'alias' => $registration->minecraft_alias,
-                'last_seen_at' => now(),
             ], uniqueBy: [
                 'uuid' => $registration->minecraft_uuid,
             ]);

--- a/app/Domains/PasswordReset/Notifications/AccountPasswordResetCompleteNotification.php
+++ b/app/Domains/PasswordReset/Notifications/AccountPasswordResetCompleteNotification.php
@@ -34,7 +34,7 @@ final class AccountPasswordResetCompleteNotification extends Notification implem
     /**
      * Get the mail representation of the notification.
      *
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/app/Http/Controllers/Api/v3/Server/MinecraftConnectionAuthController.php
+++ b/app/Http/Controllers/Api/v3/Server/MinecraftConnectionAuthController.php
@@ -42,7 +42,12 @@ final class MinecraftConnectionAuthController extends ApiController
         $playerData = null;
         $bans = $this->getBans(player: $player, ip: $validated->get('ip'));
         if ($bans === null) {
-            $player->last_seen_at = $now;
+            // Only update `last_seen_at` if the user has joined the server at least once.
+            // This keeps the field `null` so that clients can determine whether this is a
+            // first-time joiner. All users have their `last_seen_at` updated on disconnect.
+            if ($player->last_seen_at !== null) {
+                $player->last_seen_at = $now;
+            }
             $playerData = $this->getPlayerData($player);
         }
         $player->save();

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -3,13 +3,14 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Auth\Middleware\Authenticate as AuthenticateMiddleware;
+use Illuminate\Http\Request;
 
 class Authenticate extends AuthenticateMiddleware
 {
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      */
     protected function redirectTo($request)
     {

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class RedirectIfAuthenticated
@@ -10,7 +11,7 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @param  string|null  $guard
      */
     public function handle($request, Closure $next, $guard = null)

--- a/app/Http/Requests/AccountChangePasswordRequest.php
+++ b/app/Http/Requests/AccountChangePasswordRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\Validator;
 
 class AccountChangePasswordRequest extends FormRequest
 {
@@ -24,7 +25,7 @@ class AccountChangePasswordRequest extends FormRequest
     /**
      * Configure the validator instance.
      *
-     * @param  \Illuminate\Validation\Validator  $validator
+     * @param  Validator  $validator
      * @return void
      */
     public function withValidator($validator)

--- a/app/Http/Requests/AccountSaveNewEmailRequest.php
+++ b/app/Http/Requests/AccountSaveNewEmailRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Models\Account;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Validator;
 
 class AccountSaveNewEmailRequest extends FormRequest
 {
@@ -23,7 +24,7 @@ class AccountSaveNewEmailRequest extends FormRequest
     /**
      * Configure the validator instance.
      *
-     * @param  \Illuminate\Validation\Validator  $validator
+     * @param  Validator  $validator
      * @return void
      */
     public function withValidator($validator)

--- a/app/Http/Requests/SendPasswordEmailRequest.php
+++ b/app/Http/Requests/SendPasswordEmailRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Models\Account;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
 
 final class SendPasswordEmailRequest extends FormRequest
 {
@@ -30,7 +31,7 @@ final class SendPasswordEmailRequest extends FormRequest
     /**
      * Configure the validator instance.
      *
-     * @param  \Illuminate\Validation\Validator  $validator
+     * @param  Validator  $validator
      * @return void
      */
     public function withValidator($validator)

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,12 +1,25 @@
 <?php
 
 use App\Core\Data\Exceptions\BaseHttpException;
+use App\Http\Middleware\ActiveMfaSession;
+use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\LogApiCalls;
+use App\Http\Middleware\MfaAuthenticated;
+use App\Http\Middleware\NotActivated;
+use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\RequireActivation;
+use App\Http\Middleware\RequireMfaEnabled;
+use App\Http\Middleware\RequirePassword;
+use App\Http\Middleware\RequireServerToken;
+use App\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Validation\ValidationException;
@@ -32,29 +45,29 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->replace(
-            search: \Illuminate\Http\Middleware\TrustProxies::class,
-            replace: \App\Http\Middleware\TrustProxies::class,
+            search: TrustProxies::class,
+            replace: App\Http\Middleware\TrustProxies::class,
         );
         $middleware->web(append: [
-            \App\Http\Middleware\VerifyCsrfToken::class,
-            \App\Http\Middleware\HandleInertiaRequests::class,
+            VerifyCsrfToken::class,
+            HandleInertiaRequests::class,
         ]);
         $middleware->api(append: [
-            \App\Http\Middleware\LogApiCalls::class,
+            LogApiCalls::class,
         ]);
         $middleware->redirectGuestsTo(
             fn (Request $request) => route('front.login'),
         );
         $middleware->alias([
-            'active-mfa' => \App\Http\Middleware\ActiveMfaSession::class,
-            'activated' => \App\Http\Middleware\RequireActivation::class,
-            'auth' => \App\Http\Middleware\Authenticate::class,
-            'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
-            'mfa' => \App\Http\Middleware\MfaAuthenticated::class,
-            'not-activated' => \App\Http\Middleware\NotActivated::class,
-            'password.confirm' => \App\Http\Middleware\RequirePassword::class,
-            'require-mfa' => \App\Http\Middleware\RequireMfaEnabled::class,
-            'require-server-token' => \App\Http\Middleware\RequireServerToken::class,
+            'active-mfa' => ActiveMfaSession::class,
+            'activated' => RequireActivation::class,
+            'auth' => Authenticate::class,
+            'guest' => RedirectIfAuthenticated::class,
+            'mfa' => MfaAuthenticated::class,
+            'not-activated' => NotActivated::class,
+            'password.confirm' => RequirePassword::class,
+            'require-mfa' => RequireMfaEnabled::class,
+            'require-server-token' => RequireServerToken::class,
         ]);
         // Stripe webhooks need to bypass Laravel's CSRF protection
         // https://laravel.com/docs/12.x/billing#handling-stripe-webhooks

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,25 +1,44 @@
 <?php
 
+use App\AppServiceProvider;
+use App\Core\Domains\Auditing\AuditingServiceProvider;
+use App\Core\Domains\Discord\DiscordServiceProvider;
+use App\Core\Domains\MinecraftUUID\MinecraftUUIDServiceProvider;
+use App\Core\Domains\Payment\PaymentServiceProvider;
+use App\Core\Support\Cashier\CashierServiceProvider;
+use App\Core\Support\Laravel\LaravelServiceProvider;
+use App\Core\Support\Passport\PassportServiceProvider;
+use App\Core\Support\Telescope\TelescopeServiceProvider;
+use App\Domains\Activation\ActivationServiceProvider;
+use App\Domains\BuilderRankApplications\BuilderRankApplicationsServiceProvider;
+use App\Domains\Captcha\CaptchaServiceProvider;
+use App\Domains\Docs\DocsServiceProvider;
+use App\Domains\Donations\DonationServiceProvider;
+use App\Domains\Mfa\MfaServiceProvider;
+use App\Domains\MinecraftEventBus\MinecraftEventBusServiceProvider;
+use App\Domains\Permissions\PermissionsServiceProvider;
+use App\Domains\Players\PlayerServiceProvider;
+
 return [
-    App\AppServiceProvider::class,
+    AppServiceProvider::class,
 
-    App\Core\Domains\Auditing\AuditingServiceProvider::class,
-    App\Core\Domains\Discord\DiscordServiceProvider::class,
-    App\Core\Domains\MinecraftUUID\MinecraftUUIDServiceProvider::class,
-    App\Core\Domains\Payment\PaymentServiceProvider::class,
+    AuditingServiceProvider::class,
+    DiscordServiceProvider::class,
+    MinecraftUUIDServiceProvider::class,
+    PaymentServiceProvider::class,
 
-    App\Core\Support\Cashier\CashierServiceProvider::class,
-    App\Core\Support\Laravel\LaravelServiceProvider::class,
-    App\Core\Support\Passport\PassportServiceProvider::class,
-    App\Core\Support\Telescope\TelescopeServiceProvider::class,
+    CashierServiceProvider::class,
+    LaravelServiceProvider::class,
+    PassportServiceProvider::class,
+    TelescopeServiceProvider::class,
 
-    App\Domains\Activation\ActivationServiceProvider::class,
-    App\Domains\BuilderRankApplications\BuilderRankApplicationsServiceProvider::class,
-    App\Domains\Captcha\CaptchaServiceProvider::class,
-    App\Domains\Docs\DocsServiceProvider::class,
-    App\Domains\Donations\DonationServiceProvider::class,
-    App\Domains\Mfa\MfaServiceProvider::class,
-    App\Domains\MinecraftEventBus\MinecraftEventBusServiceProvider::class,
-    App\Domains\Permissions\PermissionsServiceProvider::class,
-    App\Domains\Players\PlayerServiceProvider::class,
+    ActivationServiceProvider::class,
+    BuilderRankApplicationsServiceProvider::class,
+    CaptchaServiceProvider::class,
+    DocsServiceProvider::class,
+    DonationServiceProvider::class,
+    MfaServiceProvider::class,
+    MinecraftEventBusServiceProvider::class,
+    PermissionsServiceProvider::class,
+    PlayerServiceProvider::class,
 ];

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Activity;
+
 return [
 
     /*
@@ -35,7 +37,7 @@ return [
      * It should implement the Spatie\Activitylog\Contracts\Activity interface
      * and extend Illuminate\Database\Eloquent\Model.
      */
-    'activity_model' => \App\Models\Activity::class,
+    'activity_model' => Activity::class,
 
     /*
      * This is the name of the table that will be created by the migration and

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Account;
+
 return [
 
     /*
@@ -67,7 +69,7 @@ return [
     'providers' => [
         'accounts' => [
             'driver' => 'eloquent',
-            'model' => \App\Models\Account::class,
+            'model' => Account::class,
         ],
 
         // 'users' => [

--- a/config/backup.php
+++ b/config/backup.php
@@ -6,6 +6,11 @@ use App\Domains\Backup\Notifications\CleanupHasFailedNotification;
 use App\Domains\Backup\Notifications\CleanupWasSuccessfulNotification;
 use App\Domains\Backup\Notifications\HealthyBackupWasFoundNotification;
 use App\Domains\Backup\Notifications\UnhealthyBackupWasFoundNotification;
+use Spatie\Backup\Notifications\Notifiable;
+use Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes;
+use Spatie\DbDumper\Compressors\GzipCompressor;
 
 return [
 
@@ -101,7 +106,7 @@ return [
          *
          * If you do not want any compressor at all, set it to null.
          */
-        'database_dump_compressor' => Spatie\DbDumper\Compressors\GzipCompressor::class,
+        'database_dump_compressor' => GzipCompressor::class,
 
         'destination' => [
 
@@ -165,7 +170,7 @@ return [
          * Here you can specify the notifiable to which the notifications should be sent. The default
          * notifiable will use the variables specified in this config file.
          */
-        'notifiable' => \Spatie\Backup\Notifications\Notifiable::class,
+        'notifiable' => Notifiable::class,
 
         'discord' => [
             'webhook_url' => env('DISCORD_WEBHOOK_BACKUP'),
@@ -186,8 +191,8 @@ return [
             'name' => env('APP_NAME', 'laravel-backup'),
             'disks' => ['backup'],
             'health_checks' => [
-                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
-                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+                MaximumAgeInDays::class => 1,
+                MaximumStorageInMegabytes::class => 5000,
             ],
         ],
     ],
@@ -202,7 +207,7 @@ return [
          * No matter how you configure it the default strategy will never
          * delete the newest backup.
          */
-        'strategy' => \Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy::class,
+        'strategy' => DefaultStrategy::class,
 
         'default_strategy' => [
 

--- a/config/services.php
+++ b/config/services.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Account;
+
 return [
 
     /*
@@ -35,7 +37,7 @@ return [
     ],
 
     'stripe' => [
-        'model' => \App\Models\Account::class,
+        'model' => Account::class,
         'key' => env('STRIPE_KEY'),
         'secret' => env('STRIPE_SECRET'),
         'webhook' => [

--- a/routes/web_manage.php
+++ b/routes/web_manage.php
@@ -34,6 +34,7 @@ use App\Http\Controllers\Manage\Servers\ServerController;
 use App\Http\Controllers\Manage\Servers\ServerTokenController;
 use App\Http\Controllers\Manage\Warnings\PlayerWarningController;
 use Illuminate\Support\Facades\Route;
+use Inertia\EncryptHistoryMiddleware;
 
 Route::name('manage.')
     ->prefix('manage')
@@ -43,7 +44,7 @@ Route::name('manage.')
         'mfa',
         'can:access-manage',
         'require-mfa',
-        Inertia\EncryptHistoryMiddleware::class,
+        EncryptHistoryMiddleware::class,
     ])
     ->group(function () {
         Route::get('/', HomeIndexController::class)

--- a/routes/web_review.php
+++ b/routes/web_review.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Review\BanAppeals\BanAppealController;
 use App\Http\Controllers\Review\BuilderRanks\BuilderRanksController;
 use App\Http\Controllers\Review\HomeController;
 use Illuminate\Support\Facades\Route;
+use Inertia\EncryptHistoryMiddleware;
 
 Route::name('review.')
     ->prefix('review')
@@ -13,7 +14,7 @@ Route::name('review.')
         'mfa',
         'can:access-review',
         'require-mfa',
-        Inertia\EncryptHistoryMiddleware::class,
+        EncryptHistoryMiddleware::class,
     ])
     ->group(function () {
         Route::get('/', HomeController::class)

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,13 +3,14 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
 
 trait CreatesApplication
 {
     /**
      * Creates the application.
      *
-     * @return \Illuminate\Foundation\Application
+     * @return Application
      */
     public function createApplication()
     {

--- a/tests/Integration/Front/AccountSettingsUsernameTest.php
+++ b/tests/Integration/Front/AccountSettingsUsernameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Integration\Front;
 
 use App\Models\Account;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\TestResponse;
 use Tests\TestCase;
 
 class AccountSettingsUsernameTest extends TestCase
@@ -18,7 +19,7 @@ class AccountSettingsUsernameTest extends TestCase
         $this->account = Account::factory()->create();
     }
 
-    private function submitUsernameChange($newUsername): \Illuminate\Testing\TestResponse
+    private function submitUsernameChange($newUsername): TestResponse
     {
         return $this->actingAs($this->account)->post(route('front.account.settings.username'), [
             'username' => $newUsername,

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -12,8 +15,8 @@
 */
 
 uses(
-    Tests\TestCase::class,
-    Illuminate\Foundation\Testing\RefreshDatabase::class,
+    TestCase::class,
+    RefreshDatabase::class,
 )->in('Integration', 'Unit');
 
 /*


### PR DESCRIPTION
Was causing clients to be unable to determine whether a connection was for a first-time joining player